### PR TITLE
move `adapt` call into `to_img`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -4,7 +4,8 @@ using Base64: Base64EncodePipe
 
 Base.summary(io::IO, t::Tiling) = print(io, "Order-", t.N, " ", typeof(t))
 
-function to_img(t::Tiling)
+function to_img(_t::Tiling)
+    t = adapt(Array, _t)
     img = fill(colorant"transparent", inds(t.N))
     foreach(faces(t)) do (i, j, isdotted)
         if t[i, j] == UP
@@ -82,7 +83,7 @@ Base.showable(::MIME"image/png", (; N)::Tiling) = N > 0
 
 function Base.show(io::IO, ::MIME"image/png", t::Tiling; kw...)
     io = IOContext(io, :full_fidelity => true)
-    img = to_img(adapt(Array, t))
+    img = to_img(t)
     show(io, MIME("image/png"), img; kw...)
     return nothing
 end
@@ -90,11 +91,11 @@ end
 Base.showable(::MIME"juliavscode/html", (; N)::Tiling) = N > 0
 
 function Base.show(io::IO, ::MIME"juliavscode/html", t::Tiling; kw...)
-    img = to_img(adapt(Array, t))
+    img = to_img(t)
     print(io, "<img src='data:image/gif;base64,")
     b64_io = IOContext(Base64EncodePipe(io), :full_fidelity => true)
     show(b64_io, MIME("image/png"), img; kw...)
     close(b64_io)
-    print(io, "' style='width: 100%; max-height: 500px; object-fit: contain; image-rendering: pixelated' />")
+    print(io, "' style='width: 500px; max-height: 500px; object-fit: contain; image-rendering: pixelated' />")
     return nothing
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -4,8 +4,7 @@ using Base64: Base64EncodePipe
 
 Base.summary(io::IO, t::Tiling) = print(io, "Order-", t.N, " ", typeof(t))
 
-function to_img(_t::Tiling)
-    t = adapt(Array, _t)
+function to_img(t::Tiling{Matrix{Edge}})
     img = fill(colorant"transparent", inds(t.N))
     foreach(faces(t)) do (i, j, isdotted)
         if t[i, j] == UP
@@ -18,6 +17,7 @@ function to_img(_t::Tiling)
     end
     return img
 end
+to_img(t::Tiling) = to_img(adapt(Array, t))
 
 function Base.show(io::IO, (; N, x)::Tiling)
     print(io, "Tiling(", N)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -5,7 +5,7 @@
     D = ka_diamond(200, CuArray)
     D_cpu = adapt(Array, D)
     @test verify_tiling(D_cpu)
-    @test AztecDiamonds.to_img(D) isa Matrix
+    @test AztecDiamonds.to_img(D) == AztecDiamonds.to_img(D_cpu)
 
     @testset "$rot" for rot in (rotr90, rotl90, rot180)
         D′ = rot(D)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -5,6 +5,7 @@
     D = ka_diamond(200, CuArray)
     D_cpu = adapt(Array, D)
     @test verify_tiling(D_cpu)
+    @test AztecDiamonds.to_img(D) isa Matrix
 
     @testset "$rot" for rot in (rotr90, rotl90, rot180)
         D′ = rot(D)


### PR DESCRIPTION
allows to call `to_img` on GPU tilings. Also fix vscode display
